### PR TITLE
Remove utest dependency from published package.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -52,9 +52,9 @@ object Build extends sbt.Build
   lazy val microjson = crossProject.in(file(".")).
     settings(sharedSettings: _*)
     .jsSettings(
-      libraryDependencies += "com.lihaoyi" %%% "utest" % "0.3.1"
+      libraryDependencies += "com.lihaoyi" %%% "utest" % "0.3.1" % "test"
     ).jvmSettings(
-      libraryDependencies += "com.lihaoyi" %% "utest" % "0.3.1"
+      libraryDependencies += "com.lihaoyi" %% "utest" % "0.3.1" % "test"
     )
   lazy val js = microjson.js
   lazy val jvm   = microjson.jvm


### PR DESCRIPTION
I only did very based testing (sbt test and building another project using a locally published version), but builds still work fine and that's what would probably fail from this change.